### PR TITLE
Fix NOT filters

### DIFF
--- a/lib/src/filter.dart
+++ b/lib/src/filter.dart
@@ -51,22 +51,23 @@ class Filter {
 
   Filter(this._filterType, [this._attributeName, this._assertionValue, this._subFilters]);
 
-  static Filter equals(String attributeName, String attrValue) => new Filter(TYPE_EQUALITY, attributeName, attrValue);
-
-
   static Filter and(List<Filter> filters) => new Filter(TYPE_AND, null, null, filters);
-
 
   static Filter or(List<Filter> filters) => new Filter(TYPE_OR, null, null, filters);
 
-
   static Filter not(Filter f) => new Filter(TYPE_NOT, null, null, [f]);
 
-  static Filter present(String attrName) => new Filter(TYPE_PRESENCE, attrName);
-
+  static Filter equals(String attributeName, String attrValue) => new Filter(TYPE_EQUALITY, attributeName, attrValue);
 
   static Filter substring(String pattern) => new SubstringFilter(pattern);
 
+  static Filter greaterOrEquals(String attributeName, String attrValue) => new Filter(TYPE_GREATER_OR_EQUAL, attributeName, attrValue);
+
+  static Filter lessOrEquals(String attributeName, String attrValue) => new Filter(TYPE_LESS_OR_EQUAL, attributeName, attrValue);
+
+  static Filter present(String attrName) => new Filter(TYPE_PRESENCE, attrName);
+
+  static Filter approx(String attributeName, String attrValue) => new Filter(TYPE_APPROXIMATE_MATCH, attributeName, attrValue);
 
   Filter operator &(Filter other) => Filter.and([this, other]);
   Filter operator |(Filter other) => Filter.or([this, other]);
@@ -103,15 +104,12 @@ class Filter {
 
 
       case Filter.TYPE_NOT:
-        // encoded as
-        // tag=NOT, length bytes, filter bytes....
-
+        // like AND/OR but with only one subFilter.
         assert(subFilters != null);
-        var notObj = subFilters[0];
-        assert(notObj != null);
+        var notObj = new ASN1Set(tag: filterType);
+        notObj.add(subFilters[0].toASN1());
+        return notObj;
 
-        var enc = notObj.toASN1();
-        return new ASN1Object.preEncoded(Filter.TYPE_NOT, enc.encodedBytes);
 
       case Filter.TYPE_EXTENSIBLE_MATCH:
         throw "Not Done yet. Fix me!!";

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -15,19 +15,19 @@ main() {
     });
 
     test('(foo<=bar)', () {
-      var f = new Filter(Filter.TYPE_LESS_OR_EQUAL, "foo", "bar");
+      var f = Filter.lessOrEquals("foo", "bar");
       var b = f.toASN1().encodedBytes;
       expect(b, equals([0xa6, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
     });
 
     test('(foo>=bar)', () {
-      var f = new Filter(Filter.TYPE_GREATER_OR_EQUAL, "foo", "bar");
+      var f = Filter.greaterOrEquals("foo", "bar");
       var b = f.toASN1().encodedBytes;
       expect(b, equals([0xa5, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
     });
 
     test('(foo~=bar)', () {
-      var f = new Filter(Filter.TYPE_APPROXIMATE_MATCH, "foo", "bar");
+      var f = Filter.approx("foo", "bar");
       var b = f.toASN1().encodedBytes;
       expect(b, equals([0xa8, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
     });
@@ -51,19 +51,19 @@ main() {
     });
 
     test('(!(foo<=bar))', () {
-      var f = Filter.not(new Filter(Filter.TYPE_LESS_OR_EQUAL, "foo", "bar"));
+      var f = Filter.not(Filter.lessOrEquals("foo", "bar"));
       var b = f.toASN1().encodedBytes;
       expect(b, equals([0xa2, 0x0c, 0xa6, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
     });
 
     test('(!(foo>=bar))', () {
-      var f = Filter.not(new Filter(Filter.TYPE_GREATER_OR_EQUAL, "foo", "bar"));
+      var f = Filter.not(Filter.greaterOrEquals("foo", "bar"));
       var b = f.toASN1().encodedBytes;
       expect(b, equals([0xa2, 0x0c, 0xa5, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
     });
 
     test('(!(foo~=bar))', () {
-      var f = Filter.not(new Filter(Filter.TYPE_APPROXIMATE_MATCH, "foo", "bar"));
+      var f = Filter.not(Filter.approx("foo", "bar"));
       var b = f.toASN1().encodedBytes;
       expect(b, equals([0xa2, 0x0c, 0xa8, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
     });

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -1,61 +1,84 @@
-/// Unit test for filter encodings
-
-
-/*
- * Obj C test supplied by Chris.  TODO: Convert this to a Dart unit test
- *
- * [eq writeFilter:@"(foo=bar)"];
-    uint8_t eq_bytes[] = { 0xa3, 0x0a, 0x04, 0x03, 'f', 'o', 'o', 0x04, 0x03, 'b', 'a', 'r' };
-
-    [le writeFilter:@"(foo<=bar)"];
-    uint8_t lt_bytes[] = { 0xa6, 0x0a, 0x04, 0x03, 'f', 'o', 'o', 0x04, 0x03, 'b', 'a', 'r' };
-
-    [ge writeFilter:@"(foo>=bar)"];
-    uint8_t gt_bytes[] = { 0xa5, 0x0a, 0x04, 0x03, 'f', 'o', 'o', 0x04, 0x03, 'b', 'a', 'r' };
-
-    [ap writeFilter:@"(foo~=bar)"];
-    uint8_t ap_bytes[] = { 0xa8, 0x0a, 0x04, 0x03, 'f', 'o', 'o', 0x04, 0x03, 'b', 'a', 'r' };
-
-    [ls writeFilter:@"(foo=bar*)"];
-    uint8_t ls_bytes[] = { 0xa4, 0x0c, 0x04, 0x03, 'f', 'o', 'o', 0x30, 0x05, 0x80, 0x03, 'b', 'a', 'r' };
-
-    [pr writeFilter:@"(foo=*)"];
-    uint8_t pr_bytes[] = { 0x87, 0x03, 'f', 'o', 'o' };
-
-    [ne writeFilter:@"(!(foo=bar))"];
-    uint8_t ne_bytes[] = { 0xa2, 0x0c, 0xa3, 0x0a, 0x04, 0x03, 'f', 'o', 'o', 0x04, 0x03, 'b', 'a', 'r' };
-
-    [nl writeFilter:@"(!(foo<=bar))"];
-    uint8_t nl_bytes[] = { 0xa2, 0x0c, 0xa6, 0x0a, 0x04, 0x03, 'f', 'o', 'o', 0x04, 0x03, 'b', 'a', 'r' };
-
-    [ng writeFilter:@"(!(foo>=bar))"];
-    uint8_t ng_bytes[] = { 0xa2, 0x0c, 0xa5, 0x0a, 0x04, 0x03, 'f', 'o', 'o', 0x04, 0x03, 'b', 'a', 'r' };
-
-    [na writeFilter:@"(!(foo~=bar))"];
-    uint8_t na_bytes[] = { 0xa2, 0x0c, 0xa8, 0x0a, 0x04, 0x03, 'f', 'o', 'o', 0x04, 0x03, 'b', 'a', 'r' };
-
-    [np writeFilter:@"(!(foo=*))"];
-    uint8_t np_bytes[] = { 0xa2, 0x05, 0x87, 0x03, 'f', 'o', 'o' };
-
-    [and writeFilter:@"(&(foo=bar)(baz=banana))"];
-    uint8_t and_bytes[] = { 0xa0, 0x1b,
-        0xa3, 0x0a, 0x04, 0x03, 'f', 'o', 'o', 0x04, 0x03, 'b', 'a', 'r',
-        0xa3, 0x0d, 0x04, 0x03, 'b', 'a', 'z', 0x04, 0x06, 'b', 'a', 'n', 'a', 'n', 'a' };
-        *
- */
-
+/// Unit tests for filter encodings
 
 
 import 'package:unittest/unittest.dart';
 import 'package:dartdap/dartdap.dart';
-import 'package:logging_handlers/logging_handlers_shared.dart';
 
 main() {
 
+  group('Filter Encoding', () {
 
-  test('Filter Encoding', () {
-    // put test here.
+    test('(foo=bar)', () {
+      var f = Filter.equals("foo", "bar");
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa3, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
+    });
+
+    test('(foo<=bar)', () {
+      var f = new Filter(Filter.TYPE_LESS_OR_EQUAL, "foo", "bar");
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa6, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
+    });
+
+    test('(foo>=bar)', () {
+      var f = new Filter(Filter.TYPE_GREATER_OR_EQUAL, "foo", "bar");
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa5, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
+    });
+
+    test('(foo~=bar)', () {
+      var f = new Filter(Filter.TYPE_APPROXIMATE_MATCH, "foo", "bar");
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa8, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
+    });
+
+    test('(foo=bar*)', () {
+      var f = Filter.substring("foo=bar*");
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa4, 0x0c, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x30, 0x05, 0x80, 0x03, 0x62, 0x61, 0x72]));
+    });
+
+    test('(foo=*)', () {
+      var f = Filter.present("foo");
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0x87, 0x03, 0x66, 0x6f, 0x6f]));
+    });
+
+    test('(!(foo=bar))', () {
+      var f = Filter.not(Filter.equals("foo", "bar"));
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa2, 0x0c, 0xa3, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
+    });
+
+    test('(!(foo<=bar))', () {
+      var f = Filter.not(new Filter(Filter.TYPE_LESS_OR_EQUAL, "foo", "bar"));
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa2, 0x0c, 0xa6, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
+    });
+
+    test('(!(foo>=bar))', () {
+      var f = Filter.not(new Filter(Filter.TYPE_GREATER_OR_EQUAL, "foo", "bar"));
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa2, 0x0c, 0xa5, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
+    });
+
+    test('(!(foo~=bar))', () {
+      var f = Filter.not(new Filter(Filter.TYPE_APPROXIMATE_MATCH, "foo", "bar"));
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa2, 0x0c, 0xa8, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72]));
+    });
+
+    test('(!(foo=*))', () {
+      var f = Filter.not(Filter.present("foo"));
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa2, 0x05, 0x87, 0x03, 0x66, 0x6f, 0x6f]));
+    });
+
+    test('(&(foo=bar)(baz=banana))', () {
+      var f = Filter.and([Filter.equals("foo", "bar"), Filter.equals("baz", "banana")]);
+      var b = f.toASN1().encodedBytes;
+      expect(b, equals([0xa0, 0x1b, 0xa3, 0x0a, 0x04, 0x03, 0x66, 0x6f, 0x6f, 0x04, 0x03, 0x62, 0x61, 0x72, 0xa3, 0x0d, 0x04, 0x03, 0x62, 0x61, 0x7a, 0x04, 0x06, 0x62, 0x61, 0x6e, 0x61, 0x6e, 0x61]));
+    });
 
   });
 }
-


### PR DESCRIPTION
This fixes how NOT filters are encoded. I've used tcpdump traces and also Net::LDAP's builtin ASN.1 dumping to look at how popular clients are doing this, just to be sure!
