### PR TITLE
Documentation and parameter-based LDAPConfiguration constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,53 @@
-An LDAP Client Library for Dart
+# An LDAP Client Library for Dart
 
-Implements the LDAP v3 protocol. This library depends on the ASN1 parser library .
+This library allows LDAP v3 clients to be implemented.
 
+The Lightweight Directory Access Protocol (LDAP) is a protocol for
+accessing directories. These directories are organised as a hierarchy
+(or tree) of entries. Each entry contains a set of attribute and
+values. Each entry can be identified by a _distinguished name_, which
+is a sequence of attribute/value pairs.  The LDAP protocol can be used
+to query, as well as modify, these directories.
 
-Implemented operations include BIND, ADD, MODIFY, DEL, MODIFYDN, SEARCH, COMPARE
+This library supports the LDAP v3 protocol, which is defined in
+IETF [RFC 4511](http://tools.ietf.org/html/rfc4511).
 
-Example:
+The operations supported by this implementation include: BIND, ADD,
+MODIFY, DEL, MODIFYDN, SEARCH and COMPARE.
+
+## Examples
+
+### Search
+
+Create an LDAP connection and perform a simple search using it.
+
 ```dart
-var ldapConfig = new LDAPConfiguration("ldap.yaml");
-var attrs = ["dn", "cn", "objectClass"];
-var filter = Filter.substring("cn=A*");
+var ldap_settings = {
+  "default": {
+    "host": "10.211.55.35",
+    "port": 389,
+    "bindDN": "cn=admin,dc=example,dc=com",
+    "password": "p@ssw0rd",
+    "ssl": false
+  }
+};
 
-ldapConfig.getConnection().then( (LDAPConnection ldap) {
-	ldap.search("dc=example,dc=com", filter, attrs).
-		listen( (SearchEntry entry) => print('Found $entry'));
+var ldapConfig = new LDAPConfiguration.fromMap(ldap_settings);
+
+ldapConfig.getConnection().then((LDAPConnection ldap) {
+  var attrs = ["dn", "cn", "objectClass"];
+  var filter = Filter.present("objectClass");
+
+  ldap.search("dc=example,dc=com", filter, attrs).stream
+      .listen((SearchEntry entry) => print("Found $entry"));
 });
 ```
 
-See the integration test for more examples
+### Other examples
 
-TODO List:
+See the integration test for more examples.
+
+## TODO
 
 * Documentation. For now please see integration_test.dart for sample usage
 * Improve conciseness / usability of API

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Create an LDAP connection and perform a simple search using it.
 import 'package:dartdap/dartdap.dart';
 
 void main() {
-  var ldapConfig = new LDAPConfiguration.settings("ldap.example.com", ssl: false, bindDN: "cn=admin,dc=example,dc=com", password: "p@ssw0rd");
+  var ldapConfig = new LDAPConfiguration.settings("ldap.example.com",
+                                                  ssl: false, 
+                                                  bindDN: "cn=admin,dc=example,dc=com",
+                                                  password: "p@ssw0rd");
 
   ldapConfig.getConnection().then((LDAPConnection ldap) {
     var base = "dc=example,dc=com";
@@ -52,7 +55,5 @@ See the integration test for more examples.
 * VLV Search. See [https://tools.ietf.org/html/draft-ietf-ldapext-ldapv3-vlv-09]
 * An LDIF parser would be nice for creating integration test data
 * Do we need to implement flow control so the client does not overwhelm
- the server?
-
-
+  the server?
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # An LDAP Client Library for Dart
 
-This library allows LDAP v3 clients to be implemented.
+This library is used to implement LDAP v3 clients.
 
 The Lightweight Directory Access Protocol (LDAP) is a protocol for
 accessing directories. These directories are organised as a hierarchy
-(or tree) of entries. Each entry contains a set of attribute and
-values. Each entry can be identified by a _distinguished name_, which
-is a sequence of attribute/value pairs.  The LDAP protocol can be used
-to query, as well as modify, these directories.
+of _entries_, where one or more root entries are allowed. Each entry
+contains a set of attribute and values. Each entry can be identified
+by a _distinguished name_, which is a sequence of attribute/value
+pairs.  The LDAP protocol can be used to query, as well as modify,
+these directories.
 
 This library supports the LDAP v3 protocol, which is defined in
 IETF [RFC 4511](http://tools.ietf.org/html/rfc4511).
@@ -17,33 +18,29 @@ MODIFY, DEL, MODIFYDN, SEARCH and COMPARE.
 
 ## Examples
 
-### Search
-
 Create an LDAP connection and perform a simple search using it.
 
 ```dart
-var ldap_settings = {
-  "default": {
-    "host": "10.211.55.35",
-    "port": 389,
-    "bindDN": "cn=admin,dc=example,dc=com",
-    "password": "p@ssw0rd",
-    "ssl": false
-  }
-};
+import 'package:dartdap/dartdap.dart';
 
-var ldapConfig = new LDAPConfiguration.fromMap(ldap_settings);
+void main() {
+  var ldapConfig = new LDAPConfiguration.settings("ldap.example.com", ssl: false, bindDN: "cn=admin,dc=example,dc=com", password: "p@ssw0rd");
 
-ldapConfig.getConnection().then((LDAPConnection ldap) {
-  var attrs = ["dn", "cn", "objectClass"];
-  var filter = Filter.present("objectClass");
+  ldapConfig.getConnection().then((LDAPConnection ldap) {
+    var base = "dc=example,dc=com";
+    var filter = Filter.present("objectClass");
+    var attrs = ["dn", "cn", "objectClass"];
 
-  ldap.search("dc=example,dc=com", filter, attrs).stream
-      .listen((SearchEntry entry) => print("Found $entry"));
-});
+    print("LDAP Search: baseDN=\"${base}\", attributes=${attrs}");
+
+    var count = 0;
+
+    ldap.search(base, filter, attrs).stream.listen(
+        (SearchEntry entry) => print("${++count}: $entry"),
+        onDone: () => print("Found ${count} entries"));
+  });
+}
 ```
-
-### Other examples
 
 See the integration test for more examples.
 

--- a/lib/dartdap.dart
+++ b/lib/dartdap.dart
@@ -1,3 +1,17 @@
+/// Classes for implementing LDAP v3 clients.
+///
+/// Implemented operations include BIND, ADD, MODIFY, DEL, MODIFYDN, SEARCH, COMPARE
+///
+/// # Usage
+///
+/// Create an LDAPConnection object and then invoke LDAP operations on it. The
+/// LDAPConnection object can be created directly or using the LDAPConfiguration
+/// to manage the connection settings.
+///
+/// # Example
+///
+/// See LDAPConfiguration class for some examples of how to connect to an LDAP
+/// server and perform a search.
 
 library ldapclient;
 

--- a/lib/dartdap.dart
+++ b/lib/dartdap.dart
@@ -10,8 +10,8 @@
 ///
 /// # Example
 ///
-/// See LDAPConfiguration class for some examples of how to connect to an LDAP
-/// server and perform a search.
+/// See the [LDAPConfiguration] class for examples of how to connect to an LDAP
+/// server.
 
 library ldapclient;
 

--- a/lib/src/control/control.dart
+++ b/lib/src/control/control.dart
@@ -14,7 +14,6 @@ var _clogger = new Logger("ldap_control");
 
 /**
  * An LDAP Control
- *  See
  */
 abstract class Control {
 //  static const VLV_REQUEST = "2.16.840.1.113730.3.4.9";

--- a/lib/src/ldap_configuration.dart
+++ b/lib/src/ldap_configuration.dart
@@ -8,15 +8,69 @@ import 'package:logging/logging.dart';
 import 'ldap_connection.dart';
 import 'ldap_exception.dart';
 
+/// Logger for the LDAP client library.
+///
+/// The logger name is "ldap_configuration".
 
 Logger logger = new Logger("ldap_configuration");
 
+/// A LDAP configuration settings and the underlying LDAP connection.
+///
+/// Use an instance of this class to represent the LDAP configuration
+/// settings (host, port, bind distinguished name, password, and
+/// whether the connection uses TLS/SSL).
+///
+/// It is also used to obtain an [LDAPConnection] using those settings.
+///
+/// # Example 1: settings from Map
+///
+/// Connects to an LDAP server using settings in a Map.
+///
+///     var ldap_settings = {
+///       "default": {
+///         "host": "10.211.55.35",
+///         "port": 389,
+///         "bindDN": "cn=admin,dc=example,dc=com",
+///         "password": "p@ssw0rd",
+///         "ssl": false
+///       }
+///     };
+///     
+///     var ldapConfig = new LDAPConfiguration.fromMap(ldap_settings);
+///     
+///     ldapConfig.getConnection().then((LDAPConnection ldap) {
+///       var attrs = ["dn", "cn", "objectClass"];
+///       var filter = Filter.present("objectClass");
+///
+///       ldap.search("dc=example,dc=com", filter, attrs).stream
+///           .listen((SearchEntry entry) => print("Found $entry"));
+///     });
+///     
+/// # Example 2: settings from YAML file
+///
+/// Connects to an LDAP server using settings in a YAML file.
+///
+///     var ldapConfig = new LDAPConfiguration("ldap.yaml", "default");
+///     
+///     ldapConfig.getConnection().then((LDAPConnection ldap) {
+///       var attrs = ["dn", "cn", "objectClass"];
+///       var filter = Filter.present("objectClass");
+///
+///       ldap.search("dc=example,dc=com", filter, attrs).stream
+///           .listen((SearchEntry entry) => print('Found $entry'));
+///     });
+///
+/// This example loads the LDAP configuration from a Map named "default" from
+/// the YAML file "ldap.yaml" in the current directory. That YAML file could
+/// contain:
+///
+///     default:
+///       host: "ldap.example.com"
+///       port: 389
+///       bindDN: "cn=admin,dc=example,dc=com"
+///       password: "p@ssw0rd"
+///       ssl: false
 
-/*
- * Holds LDAP connection configuration settings (host, port, bind dn, etc.)
- * and the underlying LDAP connection
- *
- */
 class LDAPConfiguration {
 
   LDAPConnection _connection;
@@ -25,15 +79,19 @@ class LDAPConfiguration {
   Map configMap;
 
   String  _configName = "default";
-
+  
   Map get config => configMap[_configName];
 
+  /// Returns the binding distinguished name.
   String get bindDN   => config['bindDN'];
+  /// Returns the password.
   String get password => config['password'];
+  /// Returns the LDAP server host.
   String get host     => config['host'];
+  /// Returns the LDAP server port number.
   int    get port     => config['port'];
 
-  // return true if this is an ssl connection
+  /// Returns true if the binding is TLS/SSL, false otherwise.
   bool get ssl {
     var x = config['ssl'];
     if( x == null || x != true)
@@ -41,26 +99,56 @@ class LDAPConfiguration {
     return true;
   }
 
-  /*
-   * Create a new LDAP configuration.
-   * If [fileName] is provided it is assumed to be a yaml file
-   * containing the ldap connection parameters. It
-   * defaults to ldap.yaml in the current directory if not provided.
-   * The optional parameter [configName] is the name of a config in the config file
-   *  It defaults to "default"
-   */
+  /// Creates a new LDAP configuration from a configuration Map in a YAML file.
+  ///
+  /// If [_fileName] is provided it is used as the filename of a YAML file
+  /// containing the LDAP connection parameters. It defaults to `ldap.yaml` in
+  /// the current directory if not provided.
+  /// 
+  /// The optional parameter [_configName] is the name of a config in the YAML
+  /// file. It defaults to "default".
+  ///
+  /// Example contents of the YAML file:
+  ///
+  ///     default:
+  ///       host: "ldap.example.com"
+  ///       port: 389
+  ///       bindDN: "cn=admin,dc=example,dc=com"
+  ///       password: "p@ssw0rd"
+  ///       ssl: false
+
   LDAPConfiguration([this._fileName = 'ldap.yaml', this._configName = "default"]);
 
 
-  /**
-   * Create an LDAP configuration from the specified map. Take
-   * care that the port number in the map is an integer value
-   */
+  /// Creates an LDAP configuration from a Map of values.
+  ///
+  /// The Map must contain an entry whose key is "default"
+  /// and the value is a Map containing the settings.
+  ///
+  /// Note: unlike using the YAML file constructor, the name of the settings
+  /// entry cannot be changed.
+  ///
+  /// The settings Map must contain these key-value pairs:
+  ///
+  /// * `host` - host name of IP address of LDAP server (String)
+  /// * `port` - port number (**int**)
+  /// * `bindDN` - distinguished name of binding entry (String)
+  /// * `password` - credential to use for binding (String)
+  ///
+  /// These key-value pairs are optional:
+  ///
+  /// * `ssl` - true if binding using TLS/SSL (bool) - defaults to false
+
   LDAPConfiguration.fromMap(Map m) {
     configMap = m;
   }
 
-  /* Return a Future<Map> with the connection configuration detais */
+  /// Return a Future<Map> with the connection configuration details.
+  ///
+  /// This method returns a Future because it might involve reading a file if
+  /// the [LDAPConfiguration] was constructed by providing it with a filename
+  /// for a YAML file.
+
   Future<Map> getConfig() async {
     if( configMap != null )
       return new Future.value(configMap);
@@ -69,15 +157,17 @@ class LDAPConfiguration {
     return configMap;
   }
 
-  /**
-   * Return a Future<LDAPConnection> using this configuration.
-   * The connection is cached so that subsequent calls will return
-   * the same connection.
-   *
-   *
-   * If the optional parameter [doBind] is true (the default),
-   * the returned connection will also be bound using the configured DN and password
-   */
+  /// Return a Future<[LDAPConnection]> using this configuration.
+  /// The connection is cached so that subsequent calls will return
+  /// the same connection.
+  ///
+  /// If the optional parameter [doBind] is true (the default),
+  /// the returned connection will also be bound using the configured DN and password
+  ///
+  /// The LDAP connection can be closed by invoking the `close` method on the
+  /// [LDAPConfiguration] or by invoking the [LDAPConnection.close] method on the
+  /// connection object.  Either approach will cause subsequent calls to
+  /// this [getConnection] method to open a new LDAP connection.
 
   Future<LDAPConnection> getConnection   ([bool doBind = true])  async {
     // if we have an existing connection - return that immediatley
@@ -97,6 +187,8 @@ class LDAPConfiguration {
     }
     return _connection;
   }
+
+  /// Closes the [LDAPconnection] that was opened with [getConnection].
 
   Future close([bool immediate = false]) {
     if( _connection == null)


### PR DESCRIPTION
I've added some basic documentation that can help beginners get started quicker.

Also, I've created a new constructor for LDAPConfiguration, where the settings can simply be passed in as parameters. The other constructors required the beginner to hunt around for documentation and look through the code to find out the format of the YAML file or the keys required in the Map - passing in well named parameters is much easier (and type safe). Also, when used in a large application, the programmer would probably want to manage configuration settings for the whole application (i.e. rather than dedicate a YAML file just for the LDAP settings) or do some validation of the settings before passing them to the LDAPConfiguration constructor (i.e. will have them as several variables rather than putting them all into a mixed-type Map of Strings and an int).

I think it would be better to have the parameter version as the default constructor, rather than having the default constructor depend on access to the file system and on YAML files. But I didn't make that change, because it would break backward compatibility. Thought there is a way to do it, and maintain backward compatibility, if you are happy for it to go in that direction.
