### PR TITLE
LDAPConfiguration refactored and changed default constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The search operation produces a stream of SearchResult objects: in
 this example, the entries are each printed out along with a total
 count at the end.
 
+To perform an anonymous bind, leave out the bindDN and password.
+
 ```dart
 import 'package:dartdap/dartdap.dart';
 

--- a/README.md
+++ b/README.md
@@ -13,21 +13,29 @@ these directories.
 This library supports the LDAP v3 protocol, which is defined in
 IETF [RFC 4511](http://tools.ietf.org/html/rfc4511).
 
-The operations supported by this implementation include: BIND, ADD,
-MODIFY, DEL, MODIFYDN, SEARCH and COMPARE.
+The LDAP operations supported by this implementation include: bind, add,
+modify, delete, modify, search and compare.
 
 ## Examples
 
 Create an LDAP connection and perform a simple search using it.
 
+This example first creates an LDAPConfiguration object with the
+settings for connecting to the LDAP server.  It then gets the
+LDAPConnection object using those settings (i.e. performs an LDAP bind
+operation). With the connection, it performs an LDAP search operation.
+The search operation produces a stream of SearchResult objects: in
+this example, the entries are each printed out along with a total
+count at the end.
+
 ```dart
 import 'package:dartdap/dartdap.dart';
 
 void main() {
-  var ldapConfig = new LDAPConfiguration.settings("ldap.example.com",
-                                                  ssl: false, 
-                                                  bindDN: "cn=admin,dc=example,dc=com",
-                                                  password: "p@ssw0rd");
+  var ldapConfig = new LDAPConfiguration("ldap.example.com",
+                                         ssl: false, 
+                                         bindDN: "cn=admin,dc=example,dc=com",
+                                         password: "p@ssw0rd");
 
   ldapConfig.getConnection().then((LDAPConnection ldap) {
     var base = "dc=example,dc=com";

--- a/lib/src/connection/ldap_transformer.dart
+++ b/lib/src/connection/ldap_transformer.dart
@@ -3,18 +3,91 @@ import 'dart:async';
 import 'dart:typed_data';
 import '../protocol/ldap_protocol.dart';
 
+Uint8List leftover = null; // TODO: fix this, must not be a static variable
+
 // Create a transformer that transform a stream of
 // raw bytes to a stream of LDAP messages
+
 createTransformer() => new StreamTransformer.fromHandlers(
     handleData: (Uint8List data, EventSink<LDAPMessage> sink) {
-      var _buf = new Uint8List.view(data.buffer);
-        var totalBytes = 0;
-        while(_buf.length > 0) {
-           var m = new LDAPMessage.fromBytes(_buf);
-           logger.fine("Received LDAP message ${m}");
-           sink.add(m);
-           totalBytes += m.messageLength;
-           // slide the buffer view window to the remaining bytes
-           _buf = new Uint8List.view(_buf.buffer,totalBytes);
+
+      logger.finest("LDAP stream transformer: received ${data.length} bytes");
+
+  var _buf;
+  if (leftover == null) {
+    // No left over bytes from before: just use the new data
+    _buf = new Uint8List.view(data.buffer);
+    ;
+  } else {
+    // There were left over bytes: concatenate the left over bytes with the new data
+    _buf = new Uint8List(leftover.length + data.length);
+    _buf.setRange(0, leftover.length, leftover);
+    _buf.setRange(leftover.length, _buf.length, data);
+    leftover = null;
+  }
+
+  do {
+    // Try to determine the length of the next ASN1 object
+
+    var value_size = null; // remains null if insufficient bytes to determine length
+    var length_size;
+    if (2 <= _buf.length) {
+      // Enough data for the start of the length field
+      int first_length_byte = _buf[1]; // length starts at position 1 (tag is at position 0)
+      if (first_length_byte & 0x80 == 0) {
+        // Single byte length
+        length_size = 1;
+        value_size = first_length_byte & 0x7F;
+      } else {
+        // Multi-byte length
+        var num_length_bytes = (first_length_byte & 0x7F);
+        if (2 + num_length_bytes <= _buf.length) {
+          // Enough data for the entire length field
+          length_size = 1 + num_length_bytes;
+          value_size = 0;
+          for (int x = 2; x < num_length_bytes + 2; x++) {
+            value_size <<= 8;
+            value_size |= _buf[x] & 0xFF;
+          }
         }
-    });
+      }
+    }
+
+    if (value_size != null && (1 + length_size + value_size) <= _buf.length) {
+      // Sufficient data for the complete ASN1 object
+
+      var message_size = (1 + length_size + value_size);
+
+      logger.fine("LDAP stream transformer: ${message_size} bytes for ASN1 object: tag=${_buf[0]}, length=${value_size} value=${new Uint8List.view(_buf.buffer, 1 + length_size, value_size)}");
+
+      if (_buf[0] == 10) {
+        logger.finest("LDAP stream transformer: got a tag 10 object"); // this is seen in search results
+      }
+      var m = new LDAPMessage.fromBytes(_buf);
+      assert(m.messageLength == message_size);
+      logger.fine("Received LDAP message ${m}");
+      sink.add(m);
+
+      if (_buf.length == message_size) {
+        _buf = null; // all bytes completely processed
+      } else {
+        _buf = new Uint8List.view(_buf.buffer, message_size); // keep unprocessed bytes
+      }
+
+    } else {
+      // Insufficient data for a complete ASN1 object
+      leftover = _buf; // save bytes until more data arrives
+      _buf = null;
+      logger.finest("LDAP stream transformer: incomplete ASN1 object: ${leftover.length} bytes retained (${leftover})");
+      break; // stop processing the buffer
+    }
+
+  } while (_buf != null);
+},
+
+handleError: (Object error, StackTrace stackTrace, EventSink<LDAPMessage> sink) {
+  assert(false);
+  logger.severe("bytes to LDAPMessage transformer: error=${error}, stacktrace=${stackTrace}");
+  throw error;
+
+});

--- a/lib/src/connection/ldap_transformer.dart
+++ b/lib/src/connection/ldap_transformer.dart
@@ -3,18 +3,108 @@ import 'dart:async';
 import 'dart:typed_data';
 import '../protocol/ldap_protocol.dart';
 
-// Create a transformer that transform a stream of
-// raw bytes to a stream of LDAP messages
-createTransformer() => new StreamTransformer.fromHandlers(
-    handleData: (Uint8List data, EventSink<LDAPMessage> sink) {
-      var _buf = new Uint8List.view(data.buffer);
-        var totalBytes = 0;
-        while(_buf.length > 0) {
-           var m = new LDAPMessage.fromBytes(_buf);
-           logger.fine("Received LDAP message ${m}");
-           sink.add(m);
-           totalBytes += m.messageLength;
-           // slide the buffer view window to the remaining bytes
-           _buf = new Uint8List.view(_buf.buffer,totalBytes);
+/// Returns a [StreamTransformer<Uint8List,LDAPMessage>] that transform a stream
+/// of bytes to a stream of LDAP messages.
+
+StreamTransformer<Uint8List, LDAPMessage> createTransformer() {
+  Uint8List leftover = null; // unused bytes from an earlier data event, or null
+
+  return new StreamTransformer.fromHandlers(
+      handleData: (Uint8List data, EventSink<LDAPMessage> sink) {
+    logger.finest("LDAP stream transformer: received ${data.length} bytes");
+
+    // Set buf to the bytes to attempt to process: leftover bytes from an
+    // earlier data event (if any) plus the new bytes in data.
+
+    var buf;
+    if (leftover == null) {
+      // No left over bytes from before: new data only
+      buf = new Uint8List.view(data.buffer);
+    } else {
+      // There were left over bytes: leftover bytes + new data
+      buf = new Uint8List(leftover.length + data.length);
+      buf.setRange(0, leftover.length, leftover);
+      buf.setRange(leftover.length, buf.length, data);
+      leftover = null;
+    }
+
+    // Try to process the bytes, until there are not enough bytes left to form a
+    // complete ASN1 object. Using a do-while loop because since this handleData
+    // function was called, there will be at least some bytes to examine.
+
+    assert(0 < buf.length);
+
+    do {
+      // Try to determine the length of the next ASN1 object
+
+      var value_size = null; // null if insufficient bytes to determine length
+      var length_size; // number of bytes used by length field
+
+      if (2 <= buf.length) {
+        // Enough data for the start of the length field
+        int first_length_byte = buf[1]; // note: tag is at position 0
+        if (first_length_byte & 0x80 == 0) {
+          // Single byte length field
+          length_size = 1;
+          value_size = first_length_byte & 0x7F;
+        } else {
+          // Multi-byte length field
+          var num_length_bytes = (first_length_byte & 0x7F);
+          if (2 + num_length_bytes <= buf.length) {
+            // Enough data for the entire length field
+            length_size = 1 + num_length_bytes;
+            value_size = 0;
+            for (int x = 2; x < num_length_bytes + 2; x++) {
+              value_size <<= 8;
+              value_size |= buf[x] & 0xFF;
+            }
+          }
         }
-    });
+      }
+
+      if (value_size != null && (1 + length_size + value_size) <= buf.length) {
+        // Got length and there is sufficient data for the complete ASN1 object
+
+        var message_size = (1 + length_size + value_size); // tag, length, data
+
+        logger.fine(
+            "LDAP stream transformer: ${message_size} bytes for ASN1 object: tag=${buf[0]}, length=${value_size} value=${new Uint8List.view(buf.buffer, 1 + length_size, value_size)}");
+
+        if (buf[0] == 10) {
+          // TODO: debug why this tag is not being parsed properly
+          logger.finest("LDAP stream transformer: got a tag 10 object");
+        }
+
+        // Create LDAPMessage from all the bytes of the complete ASN1 object.
+
+        var msg = new LDAPMessage.fromBytes(buf);
+        assert(msg.messageLength == message_size);
+        logger.fine("Received LDAP message ${msg}");
+        sink.add(msg); // put on output stream
+
+        // Update buf: discard the message's bytes and keep any remaining
+        // bytes. If no bytes remain, set buf to null to exit the do-while processing loop.
+
+        if (buf.length == message_size) {
+          buf = null; // all bytes completely processed
+        } else {
+          buf = new Uint8List.view(buf.buffer, message_size);
+        }
+      } else {
+        // Insufficient data for a complete ASN1 object.
+
+        leftover = buf; // save bytes until more data arrives
+        buf = null; // so the do-while processing loop exits
+
+        logger.finest(
+            "LDAP stream transformer: incomplete ASN1 object: ${leftover.length} bytes retained (${leftover})");
+      }
+    } while (buf != null);
+  }, handleError: (Object error, StackTrace st, EventSink<LDAPMessage> sink) {
+    logger.severe("LDAP stream transformer: error=${error}, stacktrace=${st}");
+    assert(false);
+    throw error;
+  });
+}
+
+//EOF

--- a/lib/src/connection/ldap_transformer.dart
+++ b/lib/src/connection/ldap_transformer.dart
@@ -3,91 +3,18 @@ import 'dart:async';
 import 'dart:typed_data';
 import '../protocol/ldap_protocol.dart';
 
-Uint8List leftover = null; // TODO: fix this, must not be a static variable
-
 // Create a transformer that transform a stream of
 // raw bytes to a stream of LDAP messages
-
 createTransformer() => new StreamTransformer.fromHandlers(
     handleData: (Uint8List data, EventSink<LDAPMessage> sink) {
-
-      logger.finest("LDAP stream transformer: received ${data.length} bytes");
-
-  var _buf;
-  if (leftover == null) {
-    // No left over bytes from before: just use the new data
-    _buf = new Uint8List.view(data.buffer);
-    ;
-  } else {
-    // There were left over bytes: concatenate the left over bytes with the new data
-    _buf = new Uint8List(leftover.length + data.length);
-    _buf.setRange(0, leftover.length, leftover);
-    _buf.setRange(leftover.length, _buf.length, data);
-    leftover = null;
-  }
-
-  do {
-    // Try to determine the length of the next ASN1 object
-
-    var value_size = null; // remains null if insufficient bytes to determine length
-    var length_size;
-    if (2 <= _buf.length) {
-      // Enough data for the start of the length field
-      int first_length_byte = _buf[1]; // length starts at position 1 (tag is at position 0)
-      if (first_length_byte & 0x80 == 0) {
-        // Single byte length
-        length_size = 1;
-        value_size = first_length_byte & 0x7F;
-      } else {
-        // Multi-byte length
-        var num_length_bytes = (first_length_byte & 0x7F);
-        if (2 + num_length_bytes <= _buf.length) {
-          // Enough data for the entire length field
-          length_size = 1 + num_length_bytes;
-          value_size = 0;
-          for (int x = 2; x < num_length_bytes + 2; x++) {
-            value_size <<= 8;
-            value_size |= _buf[x] & 0xFF;
-          }
+      var _buf = new Uint8List.view(data.buffer);
+        var totalBytes = 0;
+        while(_buf.length > 0) {
+           var m = new LDAPMessage.fromBytes(_buf);
+           logger.fine("Received LDAP message ${m}");
+           sink.add(m);
+           totalBytes += m.messageLength;
+           // slide the buffer view window to the remaining bytes
+           _buf = new Uint8List.view(_buf.buffer,totalBytes);
         }
-      }
-    }
-
-    if (value_size != null && (1 + length_size + value_size) <= _buf.length) {
-      // Sufficient data for the complete ASN1 object
-
-      var message_size = (1 + length_size + value_size);
-
-      logger.fine("LDAP stream transformer: ${message_size} bytes for ASN1 object: tag=${_buf[0]}, length=${value_size} value=${new Uint8List.view(_buf.buffer, 1 + length_size, value_size)}");
-
-      if (_buf[0] == 10) {
-        logger.finest("LDAP stream transformer: got a tag 10 object"); // this is seen in search results
-      }
-      var m = new LDAPMessage.fromBytes(_buf);
-      assert(m.messageLength == message_size);
-      logger.fine("Received LDAP message ${m}");
-      sink.add(m);
-
-      if (_buf.length == message_size) {
-        _buf = null; // all bytes completely processed
-      } else {
-        _buf = new Uint8List.view(_buf.buffer, message_size); // keep unprocessed bytes
-      }
-
-    } else {
-      // Insufficient data for a complete ASN1 object
-      leftover = _buf; // save bytes until more data arrives
-      _buf = null;
-      logger.finest("LDAP stream transformer: incomplete ASN1 object: ${leftover.length} bytes retained (${leftover})");
-      break; // stop processing the buffer
-    }
-
-  } while (_buf != null);
-},
-
-handleError: (Object error, StackTrace stackTrace, EventSink<LDAPMessage> sink) {
-  assert(false);
-  logger.severe("bytes to LDAPMessage transformer: error=${error}, stacktrace=${stackTrace}");
-  throw error;
-
-});
+    });

--- a/lib/src/ldap_configuration.dart
+++ b/lib/src/ldap_configuration.dart
@@ -106,8 +106,8 @@ class LDAPConfiguration {
   ///      // Authenticated bind
   ///      LDAPConfiguration.settings("ldap.example.com", ssl: true, bindDN: "cn=admin,dc=example,dc=com", password: "p@ssw0rd");
 
-  LDAPConfiguration(String hostname, {bool ssl: false, int port: null,
-      String bindDN: null, String password: null}) {
+  LDAPConfiguration(String hostname,
+      {int port, bool ssl: false, String bindDN, String password}) {
     _setAll(hostname, port, ssl, bindDN, password);
   }
 
@@ -247,8 +247,7 @@ class LDAPConfiguration {
 
     // Connect
 
-    logger.info(
-        "LDAP connection: ${ssl ? "ldaps://" : "ldap://"}${host}:${port}");
+    logger.info(this.toString());
 
     _connection = new LDAPConnection(host, port, ssl, bindDN, password);
     await _connection.connect();
@@ -274,5 +273,11 @@ class LDAPConfiguration {
       assert(_connection != null);
       return null;
     }
+  }
+
+  /// Returns a string representation of this object.
+
+  String toString() {
+    return "${ssl ? "ldaps://" : "ldap://"}${host}:${port}${(bindDN != null) ? "/${bindDN}" : ""}";
   }
 }

--- a/lib/src/ldap_configuration.dart
+++ b/lib/src/ldap_configuration.dart
@@ -1,6 +1,5 @@
 library ldap_configuration;
 
-
 import 'dart:async';
 import 'package:dart_config/default_server.dart' as server_config;
 import 'package:logging/logging.dart';
@@ -39,7 +38,7 @@ class LDAPConfiguration {
 
   Map get config => configMap[_configName];
 
-  /// Returns the binding distinguished name.
+  /// Returns the bind distinguished name.
   String get bindDN   => config['bindDN'];
   /// Returns the password.
   String get password => config['password'];
@@ -48,7 +47,7 @@ class LDAPConfiguration {
   /// Returns the LDAP server port number.
   int    get port     => config['port'];
 
-  /// Returns true if the binding is TLS/SSL, false otherwise.
+  /// Returns true if the connection is TLS/SSL, false otherwise.
   bool get ssl {
     var x = config['ssl'];
     if( x == null || x != true)
@@ -67,7 +66,7 @@ class LDAPConfiguration {
   /// standard LDAP port numbers: 389 when TLS is not used or 636 when TLS is
   /// used.
   ///
-  /// Set [bindDN] to the distinguish name for the binding. An empty string
+  /// Set [bindDN] to the distinguish name for the bind. An empty string
   /// means to perform an anonymous bind.  It defaults to an empty string.
   ///
   /// Set [password] to the password for bind. It defaults to an empty string.
@@ -81,7 +80,11 @@ class LDAPConfiguration {
   ///      // Authenticated bind
   ///      LDAPConfiguration.settings("ldap.example.com", ssl: true, bindDN: "cn=admin,dc=example,dc=com", password: "p@ssw0rd");
 
-  LDAPConfiguration.settings(String hostname, { bool ssl: false, int port: null, String bindDN: "", String password: "" }) {
+  LDAPConfiguration(String hostname, { bool ssl: false, int port: null, String bindDN: "", String password: "" }) {
+
+     if (hostname == null) {
+       hostname = "localhost";
+     }
 
      if (port == null) {
        port = (ssl) ? 636 : 389; // standard LDAPS and LDAP ports
@@ -122,7 +125,7 @@ class LDAPConfiguration {
   ///       password: "p@ssw0rd"
   ///       ssl: false
 
-  LDAPConfiguration([this._fileName = 'ldap.yaml', this._configName = "default"]);
+  LDAPConfiguration.fromFile([this._fileName = 'ldap.yaml', this._configName = "default"]);
 
 
   /// Creates an LDAP configuration from a Map of values.
@@ -137,12 +140,12 @@ class LDAPConfiguration {
   ///
   /// * `host` - host name of IP address of LDAP server (String)
   /// * `port` - port number (**int**)
-  /// * `bindDN` - distinguished name of binding entry (String)
-  /// * `password` - credential to use for binding (String)
+  /// * `bindDN` - distinguished name of the bind entry (String)
+  /// * `password` - credential to use for the bind (String)
   ///
   /// These key-value pairs are optional:
   ///
-  /// * `ssl` - true if binding using TLS/SSL (bool) - defaults to false
+  /// * `ssl` - true to use a TLS/SSL connection to the LDAP server (bool) - defaults to false
   ///
   /// # Example
   ///

--- a/lib/src/ldap_configuration.dart
+++ b/lib/src/ldap_configuration.dart
@@ -95,6 +95,8 @@ class LDAPConfiguration {
   ///
   /// Set [password] to the password for bind. It defaults to an empty string.
   ///
+  /// To perform an anonymous bind, omit the [bindDN] and [password].
+  ///
   /// Examples:
   ///
   ///      // Anonymous bind

--- a/lib/src/ldap_configuration.dart
+++ b/lib/src/ldap_configuration.dart
@@ -13,58 +13,82 @@ import 'ldap_exception.dart';
 
 Logger logger = new Logger("ldap_configuration");
 
-/// A LDAP configuration settings and the underlying LDAP connection.
+/// A LDAP configuration settings and a LDAP connection created from it.
 ///
-/// Use an instance of this class to represent the LDAP configuration
+/// Use an instance of this class to represent the LDAP server
 /// settings (host, port, bind distinguished name, password, and
 /// whether the connection uses TLS/SSL).
 ///
 /// It is also used to obtain an [LDAPConnection] using those settings.
 ///
-/// There are three ways to create an LDAP configuration:
+/// There are two ways to create an LDAP configuration:
 ///
-/// * Providing the settings as parameters using the [settings] constructor.
-/// * Providing the settings in a Map using the [fromMap] constructor.
-/// * Loading the settings from a YAML file using the default constructor.
+/// * Providing the settings as parameters using the default constructor.
+/// * Loading the settings from a YAML file using the fromFile constructor.
 
 class LDAPConfiguration {
 
-  LDAPConnection _connection;
+  // Constants
 
-  String _fileName;
-  Map configMap;
+  static const String _DEFAULT_HOST = "localhost";
+  static const int _STANDARD_LDAP_PORT = 389;
+  static const int _STANDARD_LDAPS_PORT = 636;
 
-  String  _configName = "default";
+  static const String _DEFAULT_CONFIG_NAME = "default";
 
-  Map get config => configMap[_configName];
+  // Configuration settings
 
-  /// Returns the bind distinguished name.
-  String get bindDN   => config['bindDN'];
-  /// Returns the password.
-  String get password => config['password'];
-  /// Returns the LDAP server host.
-  String get host     => config['host'];
-  /// Returns the LDAP server port number.
-  int    get port     => config['port'];
+  /// The LDAP server hostname or IP address
+  String host;
 
-  /// Returns true if the connection is TLS/SSL, false otherwise.
-  bool get ssl {
-    var x = config['ssl'];
-    if( x == null || x != true)
-      return false;
-    return true;
+  /// The LDAP server port number
+  int port;
+
+  /// Whether the connection to the LDAP server uses TLS/SSL
+  bool ssl;
+
+  /// The distinguished name of the entry for the bind operation
+  String bindDN;
+
+  /// The password used for the bind operation
+  String password;
+
+  // File details (only used if object created by the fromFile constructor)
+
+  String _fileName; // null if settings don't need to be loaded from file
+  String _configName; // name of map to use in the YAML file
+
+  // Cached connection
+
+  LDAPConnection _connection; // null if not created
+
+  // Set values
+  //
+  // This internal method is used by the default constructor and to
+  // process settings loaded from a file. It applies all the default rules
+  // for when values are not provided.
+
+  void _setAll(
+      String hostname, int port, bool ssl, String bindDN, String password) {
+    this.host = (hostname != null) ? hostname : _DEFAULT_HOST;
+    this.ssl = (ssl != null) ? ssl : false;
+    this.port = (port != null)
+        ? port
+        : ((ssl) ? _STANDARD_LDAPS_PORT : _STANDARD_LDAP_PORT);
+    this.bindDN = (bindDN != null) ? bindDN : "";
+    this.password = (password != null) ? password : "";
   }
 
-  /// Creates a new LDAP configuration.
+  /// Constructor for a new LDAP configuration.
   ///
   /// The [hostname] is the hostname of the LDAP server.
-  ///
-  /// Set [ssl] to true to connect over TLS, otherwise TLS is not used. It
-  /// defaults to false.
   ///
   /// The [port] is the port number of the LDAP server. It defaults to the
   /// standard LDAP port numbers: 389 when TLS is not used or 636 when TLS is
   /// used.
+  ///
+  /// Set [ssl] to true to connect over TLS, otherwise TLS is not used. It
+  /// defaults to false.
   ///
   /// Set [bindDN] to the distinguish name for the bind. An empty string
   /// means to perform an anonymous bind.  It defaults to an empty string.
@@ -80,34 +104,17 @@ class LDAPConfiguration {
   ///      // Authenticated bind
   ///      LDAPConfiguration.settings("ldap.example.com", ssl: true, bindDN: "cn=admin,dc=example,dc=com", password: "p@ssw0rd");
 
-  LDAPConfiguration(String hostname, { bool ssl: false, int port: null, String bindDN: "", String password: "" }) {
+  LDAPConfiguration(String hostname, {bool ssl: false, int port: null,
+      String bindDN: null, String password: null}) {
+    _setAll(hostname, port, ssl, bindDN, password);
+  }
 
-     if (hostname == null) {
-       hostname = "localhost";
-     }
-
-     if (port == null) {
-       port = (ssl) ? 636 : 389; // standard LDAPS and LDAP ports
-     }
-
-     configMap = new Map<String,Map>();
-     var m = new Map();
-     configMap[_configName] = m;
-
-     m["ssl"] = ssl;
-     m["host"] = hostname;
-     m["port"] = port;
-     m["bindDN"] = bindDN;
-     m["password"] = password;
-   }
-
-  /// Creates a new LDAP configuration from a configuration Map in a YAML file.
+  /// Constructor for a new LDAP configuration from a YAML file.
   ///
-  /// If [_fileName] is provided it is used as the filename of a YAML file
-  /// containing the LDAP connection parameters. It defaults to `ldap.yaml` in
-  /// the current directory if not provided.
+  /// The [fileName] is the name of a YAML file
+  /// containing the LDAP connection settings.
   ///
-  /// The optional parameter [_configName] is the name of a config in the YAML
+  /// The optional parameter [configName] is the name of a Map in the YAML
   /// file. It defaults to "default".
   ///
   /// # Example
@@ -121,105 +128,149 @@ class LDAPConfiguration {
   ///     default:
   ///       host: "ldap.example.com"
   ///       port: 389
+  ///       ssl: false
   ///       bindDN: "cn=admin,dc=example,dc=com"
   ///       password: "p@ssw0rd"
-  ///       ssl: false
+  ///
+  ///  The only mandatory attribute is "host". See the default constructor
+  ///  for a description of the other attributes, and their values if they are not specified.
 
-  LDAPConfiguration.fromFile([this._fileName = 'ldap.yaml', this._configName = "default"]);
+  LDAPConfiguration.fromFile(String fileName, [String configName]) {
+    assert(fileName != null && fileName.isNotEmpty);
+    assert(configName == null || configName.isNotEmpty);
 
-
-  /// Creates an LDAP configuration from a Map of values.
-  ///
-  /// The Map must contain an entry whose key is "default"
-  /// and the value is a Map containing the settings.
-  ///
-  /// Note: unlike using the YAML file constructor, the name of the settings
-  /// entry cannot be changed.
-  ///
-  /// The settings Map must contain these key-value pairs:
-  ///
-  /// * `host` - host name of IP address of LDAP server (String)
-  /// * `port` - port number (**int**)
-  /// * `bindDN` - distinguished name of the bind entry (String)
-  /// * `password` - credential to use for the bind (String)
-  ///
-  /// These key-value pairs are optional:
-  ///
-  /// * `ssl` - true to use a TLS/SSL connection to the LDAP server (bool) - defaults to false
-  ///
-  /// # Example
-  ///
-  /// Create an LDAP configuration from settings in a [Map].
-  ///
-  ///     var ldap_settings = {
-  ///       "default": {
-  ///         "host": "ldap.example.com",
-  ///         "port": 389,
-  ///         "bindDN": "cn=admin,dc=example,dc=com",
-  ///         "password": "p@ssw0rd",
-  ///         "ssl": false
-  ///       }
-  ///     };
-  ///
-  ///     var ldapConfig = new LDAPConfiguration.fromMap(ldap_settings);
-
-
-  LDAPConfiguration.fromMap(Map m) {
-    configMap = m;
+    this._fileName = fileName;
+    this._configName = (configName != null) ? configName : _DEFAULT_CONFIG_NAME;
   }
 
-  /// Return a Future<Map> with the connection configuration details.
+  /// Loads the settings from the YAML file, if needed.
   ///
-  /// This method returns a Future because it might involve reading a file if
-  /// the [LDAPConfiguration] was constructed by providing it with a filename
-  /// for a YAML file.
+  /// If the LDAPConfiguration was not created using the fromFile constructor, this method
+  /// does nothign and returns immediately.
 
-  Future<Map> getConfig() async {
-    if( configMap != null )
-      return new Future.value(configMap);
+  Future _load_values() async {
+    if (_fileName == null) {
+      // No file to load: settings are already set
+      return;
+    } else {
+      // Load settings from file
 
-    configMap = await server_config.loadConfig(_fileName);
-    return configMap;
+      var configMap = await server_config.loadConfig(_fileName);
+
+      var m = configMap[_configName];
+
+      if (m == null) {
+        throw new LDAPException("${_fileName}: missing \"${_configName}\"");
+      }
+      if (!(m is Map)) {
+        throw new LDAPException(
+            "${_fileName}: \"${_configName}\" is not a map");
+      }
+
+      // Get and check the host
+
+      var host_value = m["host"];
+      if (host_value == null) {
+        throw new LDAPException(
+            "${_fileName}: \"${_configName}\" missing \"host\"");
+      }
+      if (!(host_value is String)) {
+        throw new LDAPException(
+            "${_fileName}: host in \"${_configName}\" is not a string");
+      }
+
+      // Get and check the port
+
+      var port_value = m["port"];
+      if (port_value != null && !(port_value is int)) {
+        throw new LDAPException(
+            "${_fileName}: port in \"${_configName}\" is not an int");
+      }
+
+      // Get and check the ssl
+
+      var ssl_value = m["ssl"];
+      if (ssl_value != null && !(ssl_value is bool)) {
+        throw new LDAPException(
+            "${_fileName}: ssl in \"${_configName}\" is not true/false");
+      }
+
+      // Get and check bindDN
+
+      var bindDN_value = m["bindDN"];
+      if (bindDN_value != null && !(bindDN_value is String)) {
+        throw new LDAPException(
+            "${_fileName}: bindDN in \"${_configName}\" is not a string");
+      }
+
+      // Get and check password
+
+      var password_value = m["password"];
+      if (password_value != null && !(password_value is String)) {
+        throw new LDAPException(
+            "${_fileName}: password in \"${_configName}\" is not a string");
+      }
+
+      this._setAll(
+          host_value, port_value, ssl_value, bindDN_value, password_value);
+
+      _fileName = null; // prevent future invocations from reloading it
+      return;
+    }
   }
 
   /// Return a Future<[LDAPConnection]> using this configuration.
+  ///
   /// The connection is cached so that subsequent calls will return
-  /// the same connection.
+  /// the same connection (unless it has been closed, in which case
+  /// a new one will be created).
   ///
   /// If the optional parameter [doBind] is true (the default),
-  /// the returned connection will also be bound using the configured DN and password
+  /// the returned connection will also be bound using the configured DN and password.
   ///
   /// The LDAP connection can be closed by invoking the `close` method on the
   /// [LDAPConfiguration] or by invoking the [LDAPConnection.close] method on the
   /// connection object.  Either approach will cause subsequent calls to
   /// this [getConnection] method to open a new LDAP connection.
 
-  Future<LDAPConnection> getConnection   ([bool doBind = true])  async {
-    // if we have an existing connection - return that immediatley
-    if( _connection != null && ! _connection.isClosed())
-      return  _connection;
+  Future<LDAPConnection> getConnection([bool doBind = true]) async {
+    if (_connection != null && !_connection.isClosed()) {
+      // Use cached connection
+      return _connection;
+    }
 
-    Map m = await getConfig();
-    //
-    logger.info("Connection params $host $port ssl=$ssl");
-    _connection = new LDAPConnection(host,port,ssl,bindDN,password);
+    // Get settings (loading them from the YAML file if necessary)
+
+    await _load_values();
+
+    // Connect
+
+    logger.info(
+        "LDAP connection: ${ssl ? "ldaps://" : "ldap://"}${host}:${port}");
+
+    _connection = new LDAPConnection(host, port, ssl, bindDN, password);
     await _connection.connect();
 
-    if( doBind) {
+    // Bind
+
+    if (doBind) {
       var r = await _connection.bind();
-      if( r.resultCode != 0)
-        throw new LDAPException("BIND Failed", r);
+      if (r.resultCode != 0) throw new LDAPException("BIND Failed", r);
     }
+
     return _connection;
   }
 
   /// Closes the [LDAPconnection] that was opened with [getConnection].
 
   Future close([bool immediate = false]) {
-    if( _connection == null)
-      throw new LDAPException("Trying to close a null Connection");
-    var f = _connection.close(immediate);
-    _connection = null;
-    return f;
+    if (_connection != null) {
+      var f = _connection.close(immediate);
+      _connection = null;
+      return f;
+    } else {
+      assert(_connection != null);
+      return null;
+    }
   }
 }

--- a/lib/src/ldap_result.dart
+++ b/lib/src/ldap_result.dart
@@ -165,6 +165,9 @@ class ResultCode {
     switch(code) {
       case OK:                return "OK";
       case OPERATIONS_ERROR:  return "Operations Error";
+      case PROTOCOL_ERROR:    return "Protocol Error";
+      case TIME_LIMIT_EXCEEDED: return "Time Limit Exceeded";
+      case SIZE_LIMIT_EXCEEDED: return "Size Limit Exceeded";
       case COMPARE_TRUE:      return "Compare True";
       case COMPARE_FALSE:     return "Compare False";
       case AUTH_METHOD_NOT_SUPPORTED: return "Auth Method Not supported";

--- a/test/bind_test.dart
+++ b/test/bind_test.dart
@@ -5,7 +5,7 @@ import 'package:logging_handlers/logging_handlers_shared.dart';
 main()  {
 
   LDAPConnection ldap;
-  var ldapConfig = new LDAPConfiguration.fromFile('test/ldap.yaml');
+  var ldapConfig = new LDAPConfiguration.fromFile('test/ldap.yaml','default');
   var ldapsConfig = new LDAPConfiguration.fromFile('test/ldap.yaml','ssl-example');
 
   startQuickLogging();

--- a/test/bind_test.dart
+++ b/test/bind_test.dart
@@ -5,8 +5,8 @@ import 'package:logging_handlers/logging_handlers_shared.dart';
 main()  {
 
   LDAPConnection ldap;
-  var ldapConfig = new LDAPConfiguration('test/ldap.yaml');
-  var ldapsConfig = new LDAPConfiguration('test/ldap.yaml','ssl-example');
+  var ldapConfig = new LDAPConfiguration.fromFile('test/ldap.yaml');
+  var ldapsConfig = new LDAPConfiguration.fromFile('test/ldap.yaml','ssl-example');
 
   startQuickLogging();
 

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -1,0 +1,306 @@
+// Tests for LDAPConfiguration
+//
+// These tests do not use a LDAP server. They only test the LDAP configuration, and not
+// the connection to an LDAP server with those settings.
+//
+// Requirements: the "test/configuration_test.yaml" file
+
+import 'dart:io';
+import 'dart:math';
+import 'package:unittest/unittest.dart';
+import 'package:dartdap/dartdap.dart';
+
+const String CONFIG_FILE = "test/configuration_test.yaml";
+
+void main() {
+  var random = new Random();
+
+  var host_value = "host-${random.nextInt(65535)}.example.com";
+  var port_value = random.nextInt(65535);
+  var ssl_value = random.nextBool();
+  var bindDN_value = "dc=user-${random.nextInt(65535)},dc=example,dc=com";
+  var password_value = "password${random.nextInt(65535)}";
+
+  group("LDAP configuration default constructor", () {
+    test("setting host only", () {
+      var ldap_conf = new LDAPConfiguration(host_value);
+      expect(ldap_conf, isNotNull);
+      expect(ldap_conf.host, equals(host_value));
+      expect(ldap_conf.port, equals(389));
+      expect(ldap_conf.ssl, equals(false));
+      expect(ldap_conf.bindDN, equals(""));
+      expect(ldap_conf.password, equals(""));
+    });
+
+    test("setting host and port", () {
+      var ldap_conf = new LDAPConfiguration(host_value, port: port_value);
+      expect(ldap_conf, isNotNull);
+      expect(ldap_conf.host, equals(host_value));
+      expect(ldap_conf.port, equals(port_value));
+      expect(ldap_conf.ssl, equals(false));
+      expect(ldap_conf.bindDN, equals(""));
+      expect(ldap_conf.password, equals(""));
+    });
+
+    test("setting host and ssl", () {
+      var ldap_conf_ssl_false = new LDAPConfiguration(host_value, ssl: false);
+      expect(ldap_conf_ssl_false, isNotNull);
+      expect(ldap_conf_ssl_false.host, equals(host_value));
+      expect(ldap_conf_ssl_false.port, equals(389));
+      expect(ldap_conf_ssl_false.ssl, equals(false));
+      expect(ldap_conf_ssl_false.bindDN, equals(""));
+      expect(ldap_conf_ssl_false.password, equals(""));
+
+      var ldap_conf_ssl_true = new LDAPConfiguration(host_value, ssl: true);
+      expect(ldap_conf_ssl_true, isNotNull);
+      expect(ldap_conf_ssl_true.host, equals(host_value));
+      expect(ldap_conf_ssl_true.port, equals(636));
+      expect(ldap_conf_ssl_true.ssl, equals(true));
+      expect(ldap_conf_ssl_true.bindDN, equals(""));
+      expect(ldap_conf_ssl_true.password, equals(""));
+    });
+
+    test("setting host, port and ssl", () {
+      var ldap_conf_ssl_false =
+          new LDAPConfiguration(host_value, port: port_value, ssl: false);
+      expect(ldap_conf_ssl_false, isNotNull);
+      expect(ldap_conf_ssl_false.host, equals(host_value));
+      expect(ldap_conf_ssl_false.port, equals(port_value));
+      expect(ldap_conf_ssl_false.ssl, equals(false));
+      expect(ldap_conf_ssl_false.bindDN, equals(""));
+      expect(ldap_conf_ssl_false.password, equals(""));
+
+      var ldap_conf_ssl_true =
+          new LDAPConfiguration(host_value, port: port_value, ssl: true);
+      expect(ldap_conf_ssl_true, isNotNull);
+      expect(ldap_conf_ssl_true.host, equals(host_value));
+      expect(ldap_conf_ssl_true.port, equals(port_value));
+      expect(ldap_conf_ssl_true.ssl, equals(true));
+      expect(ldap_conf_ssl_true.bindDN, equals(""));
+      expect(ldap_conf_ssl_true.password, equals(""));
+    });
+
+    test("setting all", () {
+      var ldap_conf = new LDAPConfiguration(host_value,
+          port: port_value,
+          ssl: ssl_value,
+          bindDN: bindDN_value,
+          password: password_value);
+      expect(ldap_conf, isNotNull);
+      expect(ldap_conf.host, equals(host_value));
+      expect(ldap_conf.port, equals(port_value));
+      expect(ldap_conf.ssl, equals(ssl_value));
+      expect(ldap_conf.bindDN, equals(bindDN_value));
+      expect(ldap_conf.password, equals(password_value));
+    });
+  });
+
+  group("LDAP configuration fromFile constructor", () {
+    // create a connection. Return a future that completes when
+    // the connection is available and bound
+    setUp(() async {
+      //  ldap = await ldapConfig.getConnection();
+    });
+
+    tearDown(() {
+      // nothing to do. We can keep the connection open between tests
+    });
+
+    test("file not examined until needed", () {
+      var ldap_conf = new LDAPConfiguration.fromFile("missing.yaml", "default");
+      expect(ldap_conf, isNotNull);
+    });
+
+    test("missing file throws exception", () async {
+      try {
+        var ldap_conf = new LDAPConfiguration.fromFile("missing.yaml", "default");
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(e,
+            new isInstanceOf<String>()); // TODO: code should be improved to give a meaningful exception
+      }
+    });
+
+    test("missing config in file throws exception", () async {
+      try {
+        var ldap_conf = new LDAPConfiguration.fromFile(CONFIG_FILE, "missing");
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(e, new isInstanceOf<LDAPException>());
+      }
+    });
+
+    test("config is not a map throws exception", () async {
+      try {
+        var ldap_conf = new LDAPConfiguration.fromFile(CONFIG_FILE, "not_map");
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(e, new isInstanceOf<LDAPException>());
+      }
+    });
+
+    test("config missing host throws exception", () async {
+      try {
+        var ldap_conf = new LDAPConfiguration.fromFile(CONFIG_FILE, "is_map");
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(e, new isInstanceOf<LDAPException>());
+      }
+    });
+
+    // Add "host"
+
+    test("host not string throws exception", () async {
+      try {
+        var ldap_conf =
+            new LDAPConfiguration.fromFile(CONFIG_FILE, "host_not_string");
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(e, new isInstanceOf<LDAPException>());
+      }
+    });
+
+    test("host only loads", () async {
+      var ldap_conf = new LDAPConfiguration.fromFile(CONFIG_FILE, "host_only");
+      try {
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(ldap_conf.host, equals("no-domain.example.com")); // host loaded
+        expect(ldap_conf.port, equals(389)); // port defaults to LDAP port
+        expect(ldap_conf.ssl, equals(false)); // default to no TLS
+        expect(ldap_conf.bindDN, equals("")); // default to no bindDN
+        expect(ldap_conf.password, equals("")); // default to no password
+        expect(e, new isInstanceOf<SocketException>()); // but could not connect
+      }
+    });
+
+    // Add "port" value
+
+    test("port not int throws exception", () async {
+      var ldap_conf =
+          new LDAPConfiguration.fromFile(CONFIG_FILE, "port_not_int");
+      try {
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(e, new isInstanceOf<LDAPException>());
+      }
+    });
+
+    test("host and port value loads", () async {
+      var ldap_conf = new LDAPConfiguration.fromFile(CONFIG_FILE, "port_value");
+      try {
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(ldap_conf.host, equals("no-domain.example.com")); // host loaded
+        expect(ldap_conf.port, equals(1024)); // port defaults to LDAP port
+        expect(ldap_conf.ssl, equals(false)); // default to no TLS
+        expect(ldap_conf.bindDN, equals("")); // default to no bindDN
+        expect(ldap_conf.password, equals("")); // default to no password
+        expect(e, new isInstanceOf<SocketException>()); // but could not connect
+      }
+    });
+
+    // Add "ssl" value
+
+    test("SSL not bool throws exception", () async {
+      var ldap_conf =
+          new LDAPConfiguration.fromFile(CONFIG_FILE, "ssl_not_bool");
+      try {
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(e, new isInstanceOf<LDAPException>());
+      }
+    });
+
+    test("host and SSL false loaded correctly", () async {
+      var ldap_conf =
+          new LDAPConfiguration.fromFile(CONFIG_FILE, "no_port_ssl_false");
+      try {
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(ldap_conf.host, equals("no-domain.example.com")); // host loaded
+        expect(ldap_conf.port, equals(389)); // port defaults to LDAP port
+        expect(ldap_conf.ssl, equals(false)); // ssl loaded
+        expect(ldap_conf.bindDN, equals("")); // default to no bindDN
+        expect(ldap_conf.password, equals("")); // default to no password
+        expect(e, new isInstanceOf<SocketException>()); // but could not connect
+      }
+    });
+
+    test("host and SSL true loaded correctly", () async {
+      var ldap_conf =
+          new LDAPConfiguration.fromFile(CONFIG_FILE, "no_port_ssl_true");
+      try {
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(ldap_conf.host, equals("no-domain.example.com")); // host loaded
+        expect(ldap_conf.port, equals(636)); // port defaults to LDAPS port
+        expect(ldap_conf.ssl, equals(true)); // ssl loaded
+        expect(ldap_conf.bindDN, equals("")); // default to no bindDN
+        expect(ldap_conf.password, equals("")); // default to no password
+        expect(e, new isInstanceOf<SocketException>()); // but could not connect
+      }
+    });
+
+    test("host and SSL true loaded correctly", () async {
+      var ldap_conf =
+          new LDAPConfiguration.fromFile(CONFIG_FILE, "post_and_ssl_false");
+      try {
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(ldap_conf.host, equals("no-domain.example.com")); // host loaded
+        expect(ldap_conf.port, equals(512)); // port defaults to LDAPS port
+        expect(ldap_conf.ssl, equals(false)); // ssl loaded
+        expect(ldap_conf.bindDN, equals("")); // default to no bindDN
+        expect(ldap_conf.password, equals("")); // default to no password
+        expect(e, new isInstanceOf<SocketException>()); // but could not connect
+      }
+    });
+
+    test("host and SSL true loaded correctly", () async {
+      var ldap_conf =
+          new LDAPConfiguration.fromFile(CONFIG_FILE, "post_and_ssl_true");
+      try {
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(ldap_conf.host, equals("no-domain.example.com")); // host loaded
+        expect(ldap_conf.port, equals(512)); // port defaults to LDAPS port
+        expect(ldap_conf.ssl, equals(true)); // ssl value was loaded
+        expect(ldap_conf.bindDN, equals("")); // default to no bindDN
+        expect(ldap_conf.password, equals("")); // default to no password
+        expect(e, new isInstanceOf<SocketException>()); // but could not connect
+      }
+    });
+
+    // Add bindDN and password
+
+    test("bindDN and password loaded correctly", () async {
+      var ldap_conf =
+          new LDAPConfiguration.fromFile(CONFIG_FILE, "bindDN_and_password");
+      try {
+        await ldap_conf.getConnection();
+        expect(false, isTrue, reason: "Unreachable");
+      } catch (e) {
+        expect(ldap_conf.host, equals("no-domain.example.com")); // host loaded
+        expect(ldap_conf.port, equals(389)); // port defaults to LDAPS port
+        expect(ldap_conf.ssl, equals(false)); // ssl value was loaded
+        expect(ldap_conf.bindDN, equals("dc=example,dc=com")); // bindDN loaded
+        expect(ldap_conf.password, equals("p@ssw0rd")); // password loaded
+        expect(e, new isInstanceOf<SocketException>()); // but could not connect
+      }
+    });
+  });
+}

--- a/test/configuration_test.yaml
+++ b/test/configuration_test.yaml
@@ -1,0 +1,59 @@
+# LDAP configuration file
+#
+# For testing with configuration_test.dart
+
+not_map: 42
+
+is_map:
+  description: "This config is a map, but missing the mandatory host"
+
+# Host
+
+host_not_string:
+  host: 42
+
+host_only:
+  host: no-domain.example.com
+
+# Port
+
+port_not_int:
+  host: no-domain.example.com
+  port: "1024"
+
+port_value:
+  host: no-domain.example.com
+  port: 1024
+
+# SSL
+
+ssl_not_bool:
+  host: no-domain.example.com
+  ssl: 42
+
+no_port_ssl_false:
+  host: no-domain.example.com
+  ssl: false
+
+no_port_ssl_true:
+  host: no-domain.example.com
+  ssl: true
+
+post_and_ssl_false:
+  host: no-domain.example.com
+  port: 512
+  ssl: false
+
+post_and_ssl_true:
+  host: no-domain.example.com
+  port: 512
+  ssl: true
+
+# BindDN
+
+bindDN_and_password:
+  host: no-domain.example.com
+  bindDN: "dc=example,dc=com"
+  password: "p@ssw0rd"
+
+#EOF

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -14,7 +14,7 @@ import 'package:logging_handlers/logging_handlers_shared.dart';
 
 main() async {
   LDAPConnection ldap;
-  var ldapConfig = new LDAPConfiguration("test/ldap.yaml","default");
+  var ldapConfig = new LDAPConfiguration.fromFile("test/ldap.yaml","default");
 
   startQuickLogging();
 

--- a/test/load_test.dart
+++ b/test/load_test.dart
@@ -10,7 +10,7 @@ var dn = new DN("ou=People,dc=example,dc=com");
 
 main() {
 
-  var ldapConfig = new LDAPConfiguration('test/ldap.yaml','default');
+  var ldapConfig = new LDAPConfiguration.fromFile('test/ldap.yaml','default');
   startQuickLogging();
 
 

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -16,7 +16,7 @@ import 'package:logging/logging.dart';
 
 main()  {
   LDAPConnection ldap;
-  var ldapConfig = new LDAPConfiguration("test/ldap.yaml","default");
+  var ldapConfig = new LDAPConfiguration.fromFile("test/ldap.yaml","default");
 
   startQuickLogging();
   Logger.root.level = Level.FINEST;


### PR DESCRIPTION
Swapped the constructors so the default constructor takes the settings as parameters and the constructor that loads settings from a YAML file is named "fromFile".

Refactored implementation so values are stored as member variables rather than inside a Map, whose values are a mixture of int, bool and Strings. 
