### PR TITLE
Extra logging for LDAP transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dartdap Change Log
 
-* 0.1.0 TBD
+* 0.0.10 2016-07-07
 
 - Reformatted using Dart dartfmt for code consistency.
 - Refactored exceptions and created LdapResultExceptions for all result codes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Restructured libraries and organisation of files under the lib directory.
 - Deprecated LDAPConfiguration.
 - Moved parameters to bind method for re-binding with different credentials.
+- Fixed bug with processing received data with leftover data.
 
 * 0.0.9 2016-01-15
 

--- a/lib/src/dartdap/client/ldap_transformer.dart
+++ b/lib/src/dartdap/client/ldap_transformer.dart
@@ -26,7 +26,7 @@ StreamTransformer<Uint8List, LDAPMessage> _createLdapTransformer() {
           "Bytes received: ${data.length} (+${leftover.length} leftover)");
     }
 
-    if (Level.FINEST <= loggerRecvBytes.level) {
+    if (Level.FINEST >= loggerRecvBytes.level) {
       // If statement prevents this potentially computationally expensive
       // code to be executed if it is not needed.
       loggerRecvBytes.finest("Bytes received: ${data}");
@@ -40,6 +40,8 @@ StreamTransformer<Uint8List, LDAPMessage> _createLdapTransformer() {
 
     do {
       // Try to determine the length of the next ASN1 object
+
+      assert(buf != null);
 
       var value_size = null; // null if insufficient bytes to determine length
       var length_size; // number of bytes used by length field
@@ -98,16 +100,20 @@ StreamTransformer<Uint8List, LDAPMessage> _createLdapTransformer() {
         if (buf.length == message_size) {
           // All bytes have been processed
           buf = null; // force do-while loop to exit
+          loggerRecvBytes.finest("all bytes parsed");
         } else {
           // Still some bytes unprocessed: leave for next iteration of do-while loop
           buf =
               new Uint8List.view(buf.buffer, buf.offsetInBytes + message_size);
+          loggerRecvBytes.finest("remaining to parse: ${buf.length}");
         }
       } else {
         // Insufficient data for a complete ASN1 object.
 
         leftover = buf; // save bytes until more data arrives
         buf = null; // force do-while loop to exit
+
+        loggerRecvBytes.finest("wait for more, leftover: {leftover.length} bytes");
       }
     } while (buf != null);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdap
-version: 0.1.0-alpha-2
+version: 0.0.10
 authors:
 - Warren Strange <warren.strange@gmail.com>
 - Chris Ridd <chrisridd@mac.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdap
-version: 0.1.0-alpha
+version: 0.1.0-alpha-2
 authors:
 - Warren Strange <warren.strange@gmail.com>
 - Chris Ridd <chrisridd@mac.com>

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -279,7 +279,7 @@ void setupLogging([Level commonLevel = Level.OFF]) {
   //new Logger("ldap.send").level = Level.OFF;
   //new Logger("ldap.recv.ldap").level = Level.OFF;
   //new Logger("ldap.recv.asn1").level = Level.OFF;
-  //new Logger("ldap.recv.bytes").level = Level.OFF;
+  new Logger("ldap.recv.bytes").level = Level.ALL;
 }
 
 //----------------------------------------------------------------


### PR DESCRIPTION
Extra asserts and logging added to bytes to LDAP message transformer.

If logging is enabled with something like this:

```
  Logger.root.onRecord.listen((LogRecord rec) {
    print('${rec.time}: ${rec.loggerName}: ${rec.level.name}: ${rec.message}');
  });

  hierarchicalLoggingEnabled = true;

  //new Logger("ldap.recv.asn1").level = Level.ALL;
  new Logger("ldap.recv.bytes").level = Level.ALL;
```

You should see log messages like:

```
ldap.recv.bytes: FINE: Bytes received: 14
ldap.recv.bytes: FINEST: Bytes received: [48, 12, 2, 1, 12, 107, 7, 10, 1, 0, 4, 0, 4, 0]
ldap.recv.bytes: FINER: Bytes parsed for ASN.1 object: 14
ldap.recv.bytes: FINEST: all bytes parsed
```

Indicating the socket had received 14 bytes on the stream, the list of bytes that were received, how many were consumed in an ASN.1 message and (in this case) there were no bytes left over after parsing that one message.

In other situations, you'll see something like the following, which indicates a large number of bytes was received from the socket and was parsed into several complete ASN.1 messages:

```
ldap.recv.bytes: FINE: Bytes received: 200
ldap.recv.bytes: FINEST: Bytes received: [48, 60, 2, 1, 11, ..., 0, 4, 0, 4, 0]
ldap.recv.bytes: FINER: Bytes parsed for ASN.1 object: 62
ldap.recv.bytes: FINEST: remaining to parse: 138
ldap.recv.bytes: FINER: Bytes parsed for ASN.1 object: 62
ldap.recv.bytes: FINEST: remaining to parse: 76
ldap.recv.bytes: FINER: Bytes parsed for ASN.1 object: 62
ldap.recv.bytes: FINEST: remaining to parse: 14
ldap.recv.bytes: FINER: Bytes parsed for ASN.1 object: 14
ldap.recv.bytes: FINEST: all bytes parsed
```

From this type of logging, we should be able to see what it was trying to parse/process when it failed.

Though looking at the code, it is not obvious when a null variable could have _length_ called on it. So a few assertions have been added, just in case.
