### PR TITLE
Fixed bug when port number is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,27 @@
 # Dartdap Change Log
 
-* 0.2.0 TBD
+* 0.2.1 2016-09-26
+
+- Fixed bug when port number is null.
+
+* 0.2.0 2016-09-22
 
 - Fixed race condition with multiple open/bind/close operations in parallel.
-
-* 0.1.0 TBD
-
 - Implemented automatic mode for LdapConnection.
-- Reformatted using Dart dartfmt for code consistency.
-- Refactored exceptions and created LdapResultExceptions for all result codes.
-- Restructured libraries and organisation of files under the lib directory.
 - Deprecated LDAPConfiguration.
 - Moved parameters to bind method for re-binding with different credentials.
 
-* 0.0.9 2016-01-15
+* 0.1.0 2016-07-21
+
+- Refactored exceptions and created LdapResultExceptions for all result codes.
+- Reformatted using Dart dartfmt for code consistency.
+- Restructured libraries and organisation of files under the lib directory.
+
+* 0.0.12 2016-07-22
+
+- Fixed bug when parsing large response messages.
+
+* 0.0.9 2016-01-19
 
 - Hierarchical logging support added.
 - More bytes received than for one ASN.1 object parsing fixed.

--- a/lib/src/dartdap/client/ldap_connection.dart
+++ b/lib/src/dartdap/client/ldap_connection.dart
@@ -299,17 +299,22 @@ class LdapConnection {
   ///   before attempting to make such changes.
 
   void setProtocol(bool ssl, [int port = null]) {
-    if (port != null && port is! int) {
-      throw new ArgumentError.value(port, "port", "not an int");
+    if (port != null) {
+      if (port is! int) {
+        throw new ArgumentError.value(port, "port", "not an int");
+      }
+      if (port < 0 || 65535 < port) {
+        throw new ArgumentError.value(port, "port", "outside range of 0-65535");
+      }
     }
 
-    var newSSL = (ssl == null || !ssl) ? false : true; // treat null as false
-    var newPort = port;
-    if (newPort == null) {
-      _port = (_isSSL) ? portLdaps : portLdap; // use standard port
+    // Normalize boolean flag and set port number to default, if necessary
+    ssl = (ssl == null || !ssl) ? false : true; // treat null as false
+    if (port == null) {
+      port = (ssl) ? portLdaps : portLdap; // use standard port
     }
 
-    if (newSSL != _isSSL || newPort != _port) {
+    if (ssl != _isSSL || port != _port) {
       // Values are being changed
 
       if (state == ConnectionState.ready ||
@@ -317,8 +322,8 @@ class LdapConnection {
         throw new StateError("cannot change protocol while connection is open");
       }
 
-      _isSSL = newSSL;
-      _port = newPort;
+      _isSSL = ssl;
+      _port = port;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdap
-version: 0.2.0
+version: 0.2.1
 authors:
 - Warren Strange <warren.strange@gmail.com>
 - Chris Ridd <chrisridd@mac.com>


### PR DESCRIPTION
Minor bug fix. Will re-publish as version 0.2.1.

Fixes a logic bug when `setProtocol` is passed null as the port number. It crashed instead of correctly using the default LDAP/LDAPS port number.
