### PR TITLE
Upgrade asn1lib to 0.6.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdap
-version: 0.4.4
+version: 0.4.5
 authors:
 - Warren Strange <warren.strange@gmail.com>
 - Chris Ridd <chrisridd@mac.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ homepage: https://github.com/wstrange/dartdap
 environment:
   sdk: '>=2.4.0  <3.0.0'
 dependencies:
-  asn1lib: "^0.5.3"
+  asn1lib: "^0.6.4"
   logging: "^0.11.2"
   petitparser: "^2.4.0"
   quiver_hashcode: "^2.0.0"


### PR DESCRIPTION
This is required to solve dependency conflict when using dartdap together with steel_crypt.

```
> pub get
Resolving dependencies...
Because no versions of dartdap match >0.4.4 <0.5.0 and dartdap 0.4.4 depends on asn1lib ^0.5.3, dartdap ^0.4.4 requires asn1lib ^0.5.3.
And because steel_crypt >=1.5.4+1 depends on asn1lib ^0.6.0, dartdap ^0.4.4 is incompatible with steel_crypt >=1.5.4+1.
So, because ldap_forward_auth depends on both steel_crypt ^1.7.1+1 and dartdap ^0.4.4, version solving failed.
```