### PR TITLE
build: upgrade petitparser to 7.0.2 and lints to 6.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 dependencies:
   asn1lib: "^1.6.5"
   logging: "^1.0.0"
-  petitparser: ^6.0.2
+  petitparser: ^7.0.2
   collection: "^1.18.0"
 
 dev_dependencies:
   test: "^1.24.6"
-  lints: ^5.0.0
+  lints: ^6.1.0
 
 false_secrets:
   - test/**/*.pem


### PR DESCRIPTION
petitparser is outdated and need to be updated

Because dartdap <0.5.0 doesn't support null safety and dartdap ^0.5.0 depends on petitparser ^4.0.0-nullsafety.1, dartdap <0.6.0 requires petitparser ^4.0.0-nullsafety.1.
And because dartdap >=0.6.0 <0.6.1 depends on petitparser ^4.0.2, dartdap <0.6.1 requires petitparser ^4.0.0-nullsafety.1.
And because dartdap >=0.6.1 <0.6.5 depends on petitparser ^4.1.0 and dartdap ^0.6.5 depends on petitparser ^5.1.0, dartdap <0.7.0 requires petitparser ^4.0.0-nullsafety.1 or ^5.1.0.
And because dartdap >=0.7.0 <0.7.2 depends on petitparser ^5.4.0 and dartdap >=0.7.2 depends on petitparser ^6.0.2, every version of dartdap requires petitparser ^4.0.0-nullsafety.1 or >=5.1.0 <6.0.0 or ^6.0.2.
And because XXXXX depends on dartdap any and xml >=6.6.0 depends on petitparser ^7.0.0, xml >=6.6.0 is forbidden.